### PR TITLE
Prevent crash when an application raises an error

### DIFF
--- a/src/AppContainer.jsx
+++ b/src/AppContainer.jsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+export default class AppContainer extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {};
+  }
+  componentWillReceiveProps(newProps) {
+    if (this.props.children.props.data !== newProps.children.props.data) {
+      // data from textarea has changed. It may resolve an issue in the application.
+      this.setState({ error: null, info: null });
+    }
+  }
+  componentDidCatch(error, info) {
+    this.setState({ error, info });
+  }
+  render() {
+    if (this.state.error) {
+      return (
+        <div className="appError">
+          <p>
+            Failed to run an application &apos;{this.props.children.props.appContext.language}&apos;
+            at line {this.props.children.props.appContext.position.start.line}-{this.props.children.props.appContext.position.end.line}.
+            Fixing text content in the fenced code block may resolve the issue.
+          </p>
+          <div>{this.state.error.toString()}</div>
+          <pre>{this.state.info.componentStack}</pre>
+        </div>
+      );
+    }
+    return this.props.children;
+  }
+}
+AppContainer.propTypes = {
+  children: PropTypes.node.isRequired,
+};

--- a/src/WikiParser.js
+++ b/src/WikiParser.js
@@ -10,6 +10,7 @@ import isEqual from 'lodash/isEqual';
 import repeat from 'lodash/repeat';
 
 import Apps from './apps';
+import AppContainer from './AppContainer';
 
 const internalLink = /^[./]/;
 
@@ -74,7 +75,7 @@ export default class WikiParser {
         const appName = name.substring(4);
         const appComponent = Apps[appName];
         if (appComponent) {
-          return React.createElement(appComponent, {
+          const app = React.createElement(appComponent, {
             data: children[0],
             onEdit: ctx.onEdit,
             appContext: {
@@ -84,6 +85,7 @@ export default class WikiParser {
               position: JSON.parse(props.position),
             },
           });
+          return React.createElement(AppContainer, {}, app);
         }
         throw new Error('unknown app');
       }

--- a/src/cattaz.css
+++ b/src/cattaz.css
@@ -5,6 +5,19 @@ body {
   margin-top: 0 !important;
 }
 
+.appError {
+  margin: 0.5em 0;
+  padding: 0.1em;
+  background-color: LemonChiffon;
+}
+.appError pre {
+  margin: 0;
+  padding: 0;
+  font-size: 75%;
+  max-height: 8em;
+  overflow: auto;
+}
+
 /*
 https://github.com/tomkp/react-split-pane/blob/master/README.md#example-styling
 */


### PR DESCRIPTION
If an application on the preview pane raises an error,
the whole screen would become white.
Because applications may have errors,
the platform should prevent them from crashing.