### PR TITLE
Make port numbers configurable

### DIFF
--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -1,3 +1,4 @@
+// const webpack = require('webpack');
 const CopyWebpackPlugin = require('copy-webpack-plugin');
 
 const defaultConfigFunc = require('@storybook/react/dist/server/config/defaults/webpack.config');
@@ -25,6 +26,12 @@ function configure(base) {
       flatten: true,
     },
   ]));
+  /*
+  // FIXME Not working?
+  config.plugins.push(new webpack.DefinePlugin({
+    'process.env.PORT_WEBSOCKET': process.env.PORT_WEBSOCKET || '1234',
+  }));
+  */
   // Disable default loaders for css defnied by storybook.
   config.module.rules.forEach((l) => {
     if (l.test.source === '\\.css$') {

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@ FROM node:8.11.0
 
 ARG http_proxy
 ARG https_proxy
+ARG PORT_WEBSOCKET=1234
 
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '2'
+version: '2.1'
 services:
   web:
     build:
@@ -6,6 +6,7 @@ services:
       args:
         http_proxy: ${http_proxy}
         https_proxy: ${https_proxy}
+        PORT_WEBSOCKET: ${PORT_WEBSOCKET:-1234}
     ports:
-      - "1234:1234"
-      - "8080:8080"
+      - "${PORT_WEBSOCKET:-1234}:1234"
+      - "${PORT_WEB:-8080}:8080"

--- a/docs/ja/usage.cattaz.md
+++ b/docs/ja/usage.cattaz.md
@@ -14,6 +14,8 @@ yarn start
 
 上記コマンドを実行後、`http://localhost:8080/`にアクセスするとアプリケーションを見ることができます。
 
+デフォルトのポート番号は、Webが8080でWebSocketが1234です。ポート番号を変えるには `yarn start` の代わりに `PORT_WEB=18080 PORT_WEBSOCKET=11234 yarn start` としてください。
+
 ## Docker
 
 ```bash
@@ -22,6 +24,13 @@ docker run -it -p 8080:8080 -p 1234:1234 cattaz
 ```
 
 上記コマンドを実行後、`http://localhost:8080/`にアクセスするとアプリケーションを見ることができます。
+
+ポート番号を変えるには以下の例を参照してください、。
+
+```bash
+docker build . -t cattaz --build-arg PORT_WEBSOCKET=11234
+docker run -it -p 18080:8080 -p 11234:1234 cattaz
+```
 
 ### Docker Compose
 
@@ -32,6 +41,8 @@ docker-compose up
 ```
 
 上記コマンドを実行後、`http://localhost:8080/`にアクセスするとアプリケーションを見ることができます。
+
+ポート番号を変えるには `docker-compose up` の代わりに `PORT_WEB=18080 PORT_WEBSOCKET=11234 docker-compose up` としてください。
 
 ## Amazon EC2 Container Service
 

--- a/docs/usage.cattaz.md
+++ b/docs/usage.cattaz.md
@@ -14,6 +14,8 @@ yarn start
 
 Now you can visit `http://localhost:8080/` to view the application.
 
+Default port for web is 8080 and default port for WebSocket is 1234. To change port numbers, use `PORT_WEB=18080 PORT_WEBSOCKET=11234 yarn start` instead of `yarn start`.
+
 ## Docker
 
 ```bash
@@ -22,6 +24,13 @@ docker run -it -p 8080:8080 -p 1234:1234 cattaz
 ```
 
 Now you can visit `http://localhost:8080/` to view the application.
+
+To change port numbers, refer the example below:
+
+```bash
+docker build . -t cattaz --build-arg PORT_WEBSOCKET=11234
+docker run -it -p 18080:8080 -p 11234:1234 cattaz
+```
 
 ### Docker Compose
 
@@ -32,6 +41,8 @@ docker-compose up
 ```
 
 Now you can visit `http://localhost:8080/` to view the application.
+
+To change ports to be used, use `PORT_WEB=18080 PORT_WEBSOCKET=11234 docker-compose up` instead of `docker-compose up`.
 
 ## Amazon EC2 Container Service
 

--- a/server-websocket.js
+++ b/server-websocket.js
@@ -22,7 +22,7 @@ Y.extend(yWebsocketsServer, yMemory);
 const options = minimist(process.argv.slice(2), {
   string: ['port', 'debug', 'db'],
   default: {
-    port: process.env.PORT || '1234',
+    port: process.env.PORT_WEBSOCKET || '1234',
     debug: false,
     db: 'memory',
   },

--- a/src/AppEnabledWikiEditorCodeMirror.jsx
+++ b/src/AppEnabledWikiEditorCodeMirror.jsx
@@ -78,7 +78,7 @@ export default class AppEnabledWikiEditorCodeMirror extends React.Component {
     this.updateHeight();
     this.updateWidth();
     if (this.props.roomName) {
-      this.socket = io(`http://${window.location.hostname}:1234`);
+      this.socket = io(`http://${window.location.hostname}:${process.env.PORT_WEBSOCKET}`);
       this.socket.on('activeUser', this.handleActiveUser);
       this.y = await Y({
         db: {

--- a/src/Main.jsx
+++ b/src/Main.jsx
@@ -7,7 +7,7 @@ import Modal from 'react-modal';
 
 import logo from '../docs/assets/cattaz.svg';
 
-const url = `http://${window.location.hostname}:1234`;
+const url = `http://${window.location.hostname}:${process.env.PORT_WEBSOCKET}`;
 const timeAgoMinPeriod = 10;
 const pagesListMax = 10;
 

--- a/webpack.config.babel.js
+++ b/webpack.config.babel.js
@@ -1,6 +1,7 @@
 /* eslint import/no-extraneous-dependencies: [error, {devDependencies: true}] */
 
 import path from 'path';
+import webpack from 'webpack';
 import CopyWebpackPlugin from 'copy-webpack-plugin';
 
 const isProduction = process.env.NODE_ENV === 'production';
@@ -17,6 +18,7 @@ const js = {
   },
   devServer: {
     contentBase: 'build',
+    port: parseInt(process.env.PORT_WEB || '8080', 10),
   },
   resolve: {
     extensions: ['.js', '.jsx', '.json'],
@@ -46,6 +48,9 @@ const js = {
         flatten: true,
       },
     ]),
+    new webpack.DefinePlugin({
+      'process.env.PORT_WEBSOCKET': process.env.PORT_WEBSOCKET || '1234',
+    }),
   ],
   module: {
     rules: [


### PR DESCRIPTION
See <https://github.com/FujitsuLaboratories/cattaz/issues/19#issuecomment-377234966>.

This pull request uses [variable substitution](https://docs.docker.com/compose/compose-file/#variable-substitution) in `docker-compose.yml`.
The minimum version of docker-compose will be changed to 1.12.0 from 1.10.0.