### PR TITLE
Implement support for external applications (iframe)

### DIFF
--- a/docs/app-external.cattaz.md
+++ b/docs/app-external.cattaz.md
@@ -31,10 +31,7 @@ Cattaz sends this message to the external app whenever the data is updated. Stru
 
 ```js
 {
-  cattazState: {
-    data: '(string)',
-    appContext: { /* ... */ },
-  }
+  cattazState: { data: '(string)' }
 }
 ```
 
@@ -43,7 +40,7 @@ Your external application should store the `appContext` for sending back later i
 ### App &rarr; Cattaz: `cattazEdit`
 
 ```js
-parent.postMessage({ cattazEdit: { data, appContext } }, '*');
+parent.postMessage({ cattazEdit: { data } }, '*');
 ```
 
 Edits App’s data.

--- a/docs/app-external.cattaz.md
+++ b/docs/app-external.cattaz.md
@@ -1,0 +1,57 @@
+# External application
+
+## Application
+
+```external
+```
+
+## Demo application
+
+Here is an example external application based on [hello](./app-hello) app:
+
+```external
+https://cattaz-external-app-demo.glitch.me/
+```
+
+## How it works
+
+External Cattaz applications are rendered inside an `<iframe>` and they communicate with Cattaz via the `postMessage` API.
+
+### App &rarr; Cattaz: `cattazGetState`
+
+```js
+parent.postMessage({ cattazGetState: true }, '*');
+```
+
+Requests the latest state from Cattaz. Cattaz will then send the `cattazState` message.
+
+### Cattaz &rarr; App: `cattazState`
+
+Cattaz sends this message to the external app whenever the data is updated. Structure looks like this:
+
+```js
+{
+  cattazState: {
+    data: '(string)',
+    appContext: { /* ... */ },
+  }
+}
+```
+
+Your external application should store the `appContext` for sending back later in `cattazEdit`.
+
+### App &rarr; Cattaz: `cattazEdit`
+
+```js
+parent.postMessage({ cattazEdit: { data, appContext } }, '*');
+```
+
+Edits App’s data.
+
+### App &rarr; Cattaz: `cattazSetHeight`
+
+```js
+parent.postMessage({ cattazSetHeight: 96 }, '*');
+```
+
+Sets the height of the external app’s iframe.

--- a/docs/app-external.cattaz.md
+++ b/docs/app-external.cattaz.md
@@ -52,3 +52,10 @@ parent.postMessage({ cattazSetHeight: 96 }, '*');
 ```
 
 Sets the height of the external app’s iframe.
+
+## Avoiding infinite update loops
+
+Due to the asynchronous nature of `postMessage` APIs, if you’re not careful, race conditions may occur when multiple people are using the same external app at the same time.
+
+To avoid this situation, please follow this guideline: **If your app received state from Cattaz, please handle it silently. Do not send the same state back.** Otherwise, the app may run into the infinite update loop problem.
+

--- a/docs/apps.cattaz.md
+++ b/docs/apps.cattaz.md
@@ -9,6 +9,7 @@ Cattaz has sevral applications installed.
 |[`datematcher`](./app-datematcher)|Date matcher helps an organizer to coodinate meeting time.|
 |[`draw`](./app-draw)|Draw lots application.|
 |[`error`](./app-error)|Sample application which raises an error.|
+|[`external`](./app-external)|Run an external application in cattaz.|
 |[`hello`](./app-hello)|"Hello World" application in cattaz.|
 |[`helpful`](./app-helpful)|An application to get feedbacks via "Was this page helpful?"|
 |[`kanban`](./app-kanban)|Organize your tasks by dragging and dropping task cards.|

--- a/src/apps/ExternalApplication.jsx
+++ b/src/apps/ExternalApplication.jsx
@@ -31,7 +31,7 @@ function useDebouncedUrl(url) {
 }
 
 function ExternalApplication({ data, onEdit, appContext }) {
-  const urlMatch = data.match(/^(https?:\/\/.+)\n/);
+  const urlMatch = data.match(/^(https?:\/\/.+)(\n|$)/);
   const url = urlMatch && urlMatch[1];
   const trimLength = urlMatch && urlMatch[0].length;
 
@@ -73,13 +73,19 @@ function ExternalApplicationUrlNeeded({ onSubmit }) {
   const urlRef = React.useRef(/** @type {HTMLIFrameElement | null} */ (null));
   return (
     <form
+      style={{
+        border: '1px solid #999',
+        background: '#eee',
+        color: 'black',
+        padding: '1em',
+      }}
       onSubmit={(e) => {
         e.preventDefault();
         const submittedText = urlRef.current.value;
         onSubmit(submittedText);
       }}
     >
-      A URL is needed
+      Please enter a URL to external application:
       <br />
       <input type="url" required ref={urlRef} />
       <button type="submit">Load</button>

--- a/src/apps/ExternalApplication.jsx
+++ b/src/apps/ExternalApplication.jsx
@@ -1,0 +1,165 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+/**
+ * Delays updating the URL by 1 second.
+ * @param {string} url
+ * @returns {string} the effective URL to use
+ */
+function useDebouncedUrl(url) {
+  const [effectiveUrl, setEffectiveUrl] = React.useState(url);
+
+  // If there is not an effective URL, set it immediately.
+  if (url && !effectiveUrl) {
+    setEffectiveUrl(url);
+  }
+
+  // Otherwise, wait 1 second before updating.
+  React.useEffect(() => {
+    if (url !== effectiveUrl) {
+      const timeout = setTimeout(() => {
+        setEffectiveUrl(url);
+      }, 1000);
+      return () => {
+        clearTimeout(timeout);
+      };
+    }
+    return () => {};
+  }, [url, effectiveUrl]);
+
+  return effectiveUrl;
+}
+
+function ExternalApplication({ data, onEdit, appContext }) {
+  const urlMatch = data.match(/^(https?:\/\/.+)\n/);
+  const url = urlMatch && urlMatch[1];
+  const trimLength = urlMatch && urlMatch[0].length;
+
+  const onExternalEdit = React.useCallback((nextData, receivedAppContext) => {
+    onEdit(`${url}\n${nextData}`, receivedAppContext);
+  }, [url, onEdit]);
+
+  const effectiveUrl = useDebouncedUrl(url);
+
+  if (!effectiveUrl) {
+    return (
+      <ExternalApplicationUrlNeeded
+        onSubmit={(submittedUrl) => {
+          onEdit(`${submittedUrl}\n${data}`, appContext);
+        }}
+      />
+    );
+  }
+
+  return (
+    <ExternalApplicationHost
+      // Unmount and re-mount the iframe to prevent iframe from messing with top-level navigation.
+      key={effectiveUrl}
+      url={effectiveUrl}
+      data={data.slice(trimLength)}
+      onEdit={onExternalEdit}
+      appContext={appContext}
+    />
+  );
+}
+
+ExternalApplication.propTypes = {
+  data: PropTypes.string.isRequired,
+  onEdit: PropTypes.func.isRequired,
+  appContext: PropTypes.shape({}).isRequired,
+};
+
+function ExternalApplicationUrlNeeded({ onSubmit }) {
+  const urlRef = React.useRef(/** @type {HTMLIFrameElement | null} */ (null));
+  return (
+    <form
+      onSubmit={(e) => {
+        e.preventDefault();
+        const submittedText = urlRef.current.value;
+        onSubmit(submittedText);
+      }}
+    >
+      A URL is needed
+      <br />
+      <input type="url" required ref={urlRef} />
+      <button type="submit">Load</button>
+    </form>
+  );
+}
+
+ExternalApplicationUrlNeeded.propTypes = {
+  onSubmit: PropTypes.func.isRequired,
+};
+
+function ExternalApplicationHost({
+  url, data, onEdit, appContext,
+}) {
+  const [height, setHeight] = React.useState(120);
+  const iframeRef = React.useRef(/** @type {HTMLIFrameElement | null} */ (null));
+  const latestStateRef = React.useRef(/** @type {{ data; appContext }} */ ({ data, appContext }));
+  const onEditRef = React.useRef(onEdit);
+
+  // Handle messages from iframe
+  React.useLayoutEffect(() => {
+    /**
+     * @param {MessageEvent<HTMLIFrameElement>} e
+     */
+    const listener = (e) => {
+      const iframeWindow = iframeRef.current && iframeRef.current.contentWindow;
+      if (e.source !== iframeWindow) {
+        return;
+      }
+      if (e.data.cattazGetState) {
+        iframeWindow.postMessage({ cattazState: latestStateRef.current }, '*');
+      }
+      if (e.data.cattazEdit) {
+        const { data: nextData, appContext: receivedAppState } = e.data.cattazEdit;
+        if (typeof nextData === 'string' && typeof receivedAppState === 'object' && receivedAppState) {
+          onEditRef.current(nextData, receivedAppState);
+        }
+      }
+      if (e.data.cattazSetHeight) {
+        setHeight(e.data.cattazSetHeight);
+      }
+    };
+    window.addEventListener('message', listener);
+    return () => {
+      window.removeEventListener('message', listener);
+    };
+  }, []);
+
+  // Synchronize state with iframe
+  React.useEffect(() => {
+    latestStateRef.current = { data, appContext };
+    const iframeWindow = iframeRef.current && iframeRef.current.contentWindow;
+    if (!iframeWindow) {
+      return;
+    }
+    iframeWindow.postMessage({ cattazState: latestStateRef.current }, '*');
+  }, [data, appContext]);
+
+  // Ensure latest edit function is used
+  React.useEffect(() => {
+    onEditRef.current = onEdit;
+  }, [onEdit]);
+
+  return (
+    <iframe
+      width="100%"
+      height={height}
+      frameBorder="0"
+      src={url}
+      ref={iframeRef}
+      title={url}
+    />
+  );
+}
+
+ExternalApplicationHost.propTypes = {
+  url: PropTypes.string.isRequired,
+  data: PropTypes.string.isRequired,
+  onEdit: PropTypes.func.isRequired,
+  appContext: PropTypes.shape({}).isRequired,
+};
+
+export default ExternalApplication;

--- a/src/apps/index.js
+++ b/src/apps/index.js
@@ -15,6 +15,7 @@ import map from './MapApplication';
 import draw from './DrawApplication';
 import kanban from './KanbanApplication';
 import youtube from './YoutubeApplication';
+import external from './ExternalApplication';
 
 export default {
   bookmarks,
@@ -34,4 +35,5 @@ export default {
   draw,
   kanban,
   youtube,
+  external,
 };

--- a/src/docs.js
+++ b/src/docs.js
@@ -6,6 +6,7 @@ const files = [
   'app-datematcher',
   'app-draw',
   'app-error',
+  'app-external',
   'app-hello',
   'app-helpful',
   'app-kanban',


### PR DESCRIPTION
Ohayo gozaimasu!

Thank you for making such an awesome application.

This PR contributes support for _external applications_ in Cattaz. This allows more modularity in creating new apps. It is implemented as just another application.

It is inspired by [WebMIDILink](https://www.g200kg.com/en/docs/webmidilink/) which uses the `postMessage` API to link music-related web apps together.

## External apps?

External applications are embedded inside an `<iframe>` and and communicates with Cattaz through the `postMessage` API. Why might this be useful?

- **New applications can be built and deployed separately from Cattaz.** To create new apps, you do not need to change Cattaz’s source code; just upload an HTML file.

- **Applications can be written in any framework.** [The demo application](https://glitch.com/edit/#!/cattaz-external-app-demo?path=index.html), for example, uses Vue.

Thank you for your consideration.